### PR TITLE
Skip pycountry upgrades to 22.3.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
+    ignore:
+      - dependency-name: pycountry
+        versions: ["22.3.5"] # this version failed the readthedocs build
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"


### PR DESCRIPTION
As this version breaks the readthedocs build