### PR TITLE
fix: `Llama3InstructModel`-prompt includes "<|eot_id|>" instead of "<…

### DIFF
--- a/src/intelligence_layer/core/model.py
+++ b/src/intelligence_layer/core/model.py
@@ -288,7 +288,7 @@ class Llama3InstructModel(ControlModel):
 
 {% promptrange instruction %}{{instruction}}{% endpromptrange %}{% if input %}
 
-{% promptrange input %}{{input}}{% endpromptrange %}{% endif %}<eot_id><|start_header_id|>assistant<|end_header_id|>{% if response_prefix %}
+{% promptrange input %}{{input}}{% endpromptrange %}{% endif %}<|eot_id|><|start_header_id|>assistant<|end_header_id|>{% if response_prefix %}
 
 {{response_prefix}}{% endif %}"""
     )


### PR DESCRIPTION
…eot_id>"

# Description
No description.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
