### PR TITLE
fix: highlights align properly with chunk in `MultipleChunkRetrieverQ…

### DIFF
--- a/src/intelligence_layer/use_cases/qa/multiple_chunk_retriever_qa.py
+++ b/src/intelligence_layer/use_cases/qa/multiple_chunk_retriever_qa.py
@@ -133,7 +133,7 @@ class MultipleChunkRetrieverQa(
         highlights_per_chunk = self._get_highlights_per_chunk(
             chunk_start_indices, single_chunk_qa_output.highlights
         )
-        
+
         return MultipleChunkRetrieverQaOutput(
             answer=single_chunk_qa_output.answer,
             sources=[


### PR DESCRIPTION
…a`-output

# Description
No description.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
