### PR TITLE
fix: remove installation of sphinx in doctest workflow

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -85,9 +85,7 @@ jobs:
         run: |
           poetry config installer.max-workers 10
           poetry install --no-interaction
-          - name: install Sphinx
-          run: sudo apt-get update -y && sudo apt-get install python3-sphinx
-      - name: run doctest
+      - name: Run doctest
         env:
           AA_TOKEN: ${{ secrets.AA_TOKEN }}
           HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}


### PR DESCRIPTION
# Description
Explicit installation of Sphinx is no longer necessary as it is already available. In addtion the wrong indenting of the corresponding lines in the `sdk-test.yml` caused the CI to fail if the CI does not use the chache.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
