### PR TITLE
fix: confusion matrix persistence on disc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Check the how-to for detailed information [here](./src/documentation/how_tos/how
 
 ### Fixes
  - Improve description of using artifactory tokens for installation of IL
+ - Change `confusion_matrix` in `SingleLabelClassifyAggregationLogic` such that it can be persisted in a file repository
 
 ### Deprecations
 ...

--- a/src/intelligence_layer/examples/__init__.py
+++ b/src/intelligence_layer/examples/__init__.py
@@ -1,3 +1,4 @@
+from .classify.classify import AggregatedLabelInfo as AggregatedLabelInfo
 from .classify.classify import (
     AggregatedMultiLabelClassifyEvaluation as AggregatedMultiLabelClassifyEvaluation,
 )

--- a/src/intelligence_layer/examples/classify/classify.py
+++ b/src/intelligence_layer/examples/classify/classify.py
@@ -90,9 +90,9 @@ class AggregatedSingleLabelClassifyEvaluation(BaseModel):
     """
 
     percentage_correct: float
-    confusion_matrix: Mapping[tuple[str, str], int]
-    by_label: Mapping[str, AggregatedLabelInfo]
-    missing_labels: Mapping[str, int]
+    confusion_matrix: dict[str, dict[str, int]]
+    by_label: dict[str, AggregatedLabelInfo]
+    missing_labels: dict[str, int]
 
 
 class SingleLabelClassifyAggregationLogic(
@@ -105,14 +105,16 @@ class SingleLabelClassifyAggregationLogic(
     ) -> AggregatedSingleLabelClassifyEvaluation:
         acc = MeanAccumulator()
         missing_labels: dict[str, int] = defaultdict(int)
-        confusion_matrix: dict[tuple[str, str], int] = defaultdict(int)
+        confusion_matrix: dict[str, dict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
         by_label: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
         for evaluation in evaluations:
             acc.add(1.0 if evaluation.correct else 0.0)
             if evaluation.expected_label_missing:
                 missing_labels[evaluation.expected] += 1
             else:
-                confusion_matrix[(evaluation.predicted, evaluation.expected)] += 1
+                confusion_matrix[evaluation.predicted][evaluation.expected] += 1
                 by_label[evaluation.predicted]["predicted"] += 1
                 by_label[evaluation.expected]["expected"] += 1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,21 @@ from intelligence_layer.connectors import (
     QdrantInMemoryRetriever,
     RetrieverType,
 )
-from intelligence_layer.core import LuminousControlModel, NoOpTracer, Task, TaskSpan
+from intelligence_layer.core import (
+    LuminousControlModel,
+    NoOpTracer,
+    Task,
+    TaskSpan,
+    utc_now,
+)
 from intelligence_layer.evaluation import (
     AsyncInMemoryEvaluationRepository,
+    EvaluationOverview,
     InMemoryAggregationRepository,
     InMemoryDatasetRepository,
     InMemoryEvaluationRepository,
     InMemoryRunRepository,
+    RunOverview,
 )
 
 
@@ -154,3 +162,36 @@ def in_memory_aggregation_repository() -> InMemoryAggregationRepository:
 @fixture()
 def async_in_memory_evaluation_repository() -> AsyncInMemoryEvaluationRepository:
     return AsyncInMemoryEvaluationRepository()
+
+
+@fixture
+def run_overview() -> RunOverview:
+    return RunOverview(
+        dataset_id="dataset-id",
+        id="run-id-1",
+        start=utc_now(),
+        end=utc_now(),
+        failed_example_count=0,
+        successful_example_count=3,
+        description="test run overview 1",
+    )
+
+
+@fixture
+def evaluation_id() -> str:
+    return "evaluation-id-1"
+
+
+@fixture
+def evaluation_overview(
+    evaluation_id: str, run_overview: RunOverview
+) -> EvaluationOverview:
+    return EvaluationOverview(
+        id=evaluation_id,
+        start_date=utc_now(),
+        end_date=utc_now(),
+        successful_evaluation_count=1,
+        failed_evaluation_count=1,
+        run_overviews=frozenset([run_overview]),
+        description="test evaluation overview 1",
+    )

--- a/tests/evaluation/conftest.py
+++ b/tests/evaluation/conftest.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from os import getenv
 from pathlib import Path
 from typing import Iterable, Sequence
@@ -29,7 +28,6 @@ from intelligence_layer.evaluation import (
     InMemoryDatasetRepository,
     InMemoryRunRepository,
     Runner,
-    RunOverview,
 )
 from tests.conftest import DummyStringInput, DummyStringOutput
 
@@ -67,11 +65,6 @@ def sequence_examples() -> Iterable[Example[str, None]]:
         Example(input=FAIL_IN_TASK_INPUT, expected_output=None, id="example-2"),
         Example(input=FAIL_IN_EVAL_INPUT, expected_output=None, id="example-3"),
     ]
-
-
-@fixture
-def evaluation_id() -> str:
-    return "evaluation-id-1"
 
 
 @fixture
@@ -116,44 +109,15 @@ def dummy_aggregated_evaluation() -> DummyAggregatedEvaluation:
 
 
 @fixture
-def run_overview() -> RunOverview:
-    return RunOverview(
-        dataset_id="dataset-id",
-        id="run-id-1",
-        start=utc_now(),
-        end=utc_now(),
-        failed_example_count=0,
-        successful_example_count=3,
-        description="test run overview 1",
-    )
-
-
-@fixture
-def evaluation_overview(
-    evaluation_id: str, run_overview: RunOverview
-) -> EvaluationOverview:
-    return EvaluationOverview(
-        id=evaluation_id,
-        start_date=utc_now(),
-        end_date=utc_now(),
-        successful_evaluation_count=1,
-        failed_evaluation_count=1,
-        run_overviews=frozenset([run_overview]),
-        description="test evaluation overview 1",
-    )
-
-
-@fixture
 def aggregation_overview(
     evaluation_overview: EvaluationOverview,
     dummy_aggregated_evaluation: DummyAggregatedEvaluation,
 ) -> AggregationOverview[DummyAggregatedEvaluation]:
-    now = datetime.now()
     return AggregationOverview(
         evaluation_overviews=frozenset([evaluation_overview]),
         id="aggregation-id",
-        start=now,
-        end=now,
+        start=utc_now(),
+        end=utc_now(),
         successful_evaluation_count=5,
         crashed_during_evaluation_count=3,
         description="dummy-evaluator",


### PR DESCRIPTION
fix: Change `confusion_matrix` in `SingleLabelClassifyAggregationLogic` such that it can be persisted on disc

TASK: IL-475

# Description
No description.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
