### PR TITLE
fix: `ExpandChunks` is fast even for large documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### New Features
 ...
 ### Fixes
-...
+- `ExpandChunks`-task is now fast even for very large documents
+
 ### Deprecations
 ...
 

--- a/src/intelligence_layer/core/chunk.py
+++ b/src/intelligence_layer/core/chunk.py
@@ -98,7 +98,6 @@ class ChunkWithIndices(Task[ChunkInput, ChunkWithIndicesOutput]):
 
     def __init__(self, model: AlephAlphaModel, max_tokens_per_chunk: int = 512):
         super().__init__()
-        self._max_tokens = max_tokens_per_chunk
         self._splitter = TextSplitter.from_huggingface_tokenizer(
             model.get_tokenizer(), capacity=max_tokens_per_chunk, trim=False
         )

--- a/src/intelligence_layer/core/chunk.py
+++ b/src/intelligence_layer/core/chunk.py
@@ -60,7 +60,7 @@ class Chunk(Task[ChunkInput, ChunkOutput]):
         return ChunkOutput(chunks=chunks)
 
 
-class ChunkWithStartEndIndices(BaseModel):
+class ChunkWithStartEndIndices(BaseModel, frozen=True):
     """A `TextChunk` and its `start_index` and `end_index` within the given text.
 
     Attributes:
@@ -98,6 +98,7 @@ class ChunkWithIndices(Task[ChunkInput, ChunkWithIndicesOutput]):
 
     def __init__(self, model: AlephAlphaModel, max_tokens_per_chunk: int = 512):
         super().__init__()
+        self._max_tokens = max_tokens_per_chunk
         self._splitter = TextSplitter.from_huggingface_tokenizer(
             model.get_tokenizer(), capacity=max_tokens_per_chunk, trim=False
         )


### PR DESCRIPTION
# Description
No description.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
