### PR TITLE
fix: URL-encode document names in document index client requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  - Add `elo_qa_eval` tutorial notebook describing the use of an (incremental) Elo evaluation use case for QA models.
 ### Fixes
 - `ExpandChunks`-task is now fast even for very large documents
+- The document index client now correctly URL-encodes document names in its queries.
 
 ### Deprecations
 ...


### PR DESCRIPTION
# Description
Prior to this commit, we did not URL-encode document names when querying
the document index. This caused problems when names have special
characters, i.e., '/' or '?'. We do not need to URL-encode other parts
of the URL (e.g., namespace or collection) as these are already
constrained to URL-safe characters. In addition to this fix, this commit
includes the following changes:
- update `DocumentPath.from_slash_separated_str` to correctly delimit
  paths whose document name contains a forward slash. Ideally we'd
  remove both this and `DocumentPath.to_slash_separated_str` in the
  future.
- parametrize tests to include special characters and increase coverage
- migrate to new document index collection to avoid CI conflicts

## Before Merging
 - [ ] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [ ] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
