### PR TITLE
Revert "fix: Workaround for dependabot commit message bug (#858)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,20 +14,12 @@ updates:
         update-types:
           - minor
           - patch
-    commit-message:  # Workaround for bug https://github.com/dependabot/dependabot-core/issues/9784. Block can be removed once it's fixed
-      prefix: "build(deps)"
-      prefix-development: "build(deps-dev)"
-      include: "scope"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"
     schedule:
       interval: "daily"
-    commit-message: # Workaround for bug https://github.com/dependabot/dependabot-core/issues/9784. Block can be removed once it's fixed
-      prefix: "build(deps)"
-      prefix-development: "build(deps-dev)"
-      include: "scope"
 
   - package-ecosystem: "npm"
     directory: "/trace-viewer/"
@@ -38,16 +30,8 @@ updates:
         update-types:
           - minor
           - patch
-    commit-message: # Workaround for bug https://github.com/dependabot/dependabot-core/issues/9784. Block can be removed once it's fixed
-      prefix: "build(deps)"
-      prefix-development: "build(deps-dev)"
-      include: "scope"
 
   - package-ecosystem: "docker"
     directory: "/trace-viewer/"
     schedule:
       interval: "daily"
-    commit-message: # Workaround for bug https://github.com/dependabot/dependabot-core/issues/9784. Block can be removed once it's fixed
-      prefix: "build(deps)"
-      prefix-development: "build(deps-dev)"
-      include: "scope"


### PR DESCRIPTION
Reverting workaround because bug has been fixed in dependabot.

This reverts commit 30c301e56fe5d93eaf21559773e417536e148e0a.

# Description
No description.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [ NA] Update `changelog.md` if necessary
 - [ NA] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
