### PR TITLE
fix: spurious mkdir failure if the file actually exists

### DIFF
--- a/src/intelligence_layer/evaluation/infrastructure/file_system_based_repository.py
+++ b/src/intelligence_layer/evaluation/infrastructure/file_system_based_repository.py
@@ -36,7 +36,10 @@ class FileSystemBasedRepository(ABC):
     def mkdir(self, path: Path) -> None:
         if self.exists(path):
             return
-        self._file_system.makedir(self.path_to_str(path), create_parents=True)
+        try:
+            self._file_system.makedir(self.path_to_str(path), create_parents=True)
+        except FileExistsError:
+            return
 
     def file_names(self, path: Path, file_type: str = "json") -> Sequence[str]:
         files = [


### PR DESCRIPTION
# Description
We run evaluations in parallel and for this a folder with results had to be created. This spuriously failed with `FileExistsError`.

Explanation for the bug:
- Assume two threads run `FileSystemBasedRepository.mkdir` to create the same directory 
- Thread1 and Thread2 both check that the directory does not exist
- Thread1 sucessfully creates the directory
- Thread2 tries to create the directory but fails with `FileExistsError` as the directory was already created by Thread1.

The result is that the entire evaluation fails with  `FileExistsError`.

## Before Merging
 - [ ] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [ ] Update `changelog.md` if necessary
 - [ ] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
