### PR TITLE
fix: expand chunk index error for large texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
  - `run_dataset` now has a flag `trace_examples_individually` to create `Tracer`s for each example. Defaults to True.
 
 ### Fixes
-  - ControlModels throw warning instead of error in case a not recommended model is selected.
-  - Cap `LimitedConcurrencyClient.max_concurrency` at 10 and set default to 10.
-
+  - ControlModels throw a warning instead of an error in case a not-recommended model is selected.
+  - The `LimitedConcurrencyClient.max_concurrency` is now capped at 10, which is its default, as the underlying `aleph_alpha_client` does not support more currently.
+  - ExpandChunk now works properly if the chunk of interest is not at the beginning of a very large document. As a consequence, `MultipleChunkRetrieverQa` now works better with larger documents and should return fewer `None` answers.
 ### Deprecations
 ...
 

--- a/tests/examples/search/test_expand_chunk.py
+++ b/tests/examples/search/test_expand_chunk.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Sequence
+from typing import Optional, Sequence
 
 from pytest import fixture
 
@@ -9,6 +9,10 @@ from intelligence_layer.connectors import (
     QdrantInMemoryRetriever,
 )
 from intelligence_layer.connectors.document_index.document_index import DocumentPath
+from intelligence_layer.connectors.retrievers.base_retriever import (
+    BaseRetriever,
+    SearchResult,
+)
 from intelligence_layer.connectors.retrievers.document_index_retriever import (
     DocumentIndexRetriever,
 )
@@ -203,3 +207,44 @@ def test_expand_chunk_is_fast_with_large_document(
 
     assert len(output.chunks) == 1
     assert elapsed < timedelta(seconds=10)
+
+
+class FakeRetriever(BaseRetriever[str]):
+    def __init__(self, result: str) -> None:
+        super().__init__()
+        self.result = result
+
+    def get_relevant_documents_with_scores(
+        self, query: str
+    ) -> Sequence[SearchResult[str]]:
+        return []
+
+    def get_full_document(self, id: str) -> Optional[Document]:
+        return Document(text=self.result)
+
+
+def test_expand_chunks_works_if_chunk_of_interest_is_outside_first_large_chunk(
+    luminous_control_model: LuminousControlModel,
+    no_op_tracer: NoOpTracer,
+) -> None:
+    # given
+    task_input = ExpandChunksInput(
+        document_id="id",
+        chunks_found=[
+            DocumentChunk(
+                text="",
+                start=1500,  # outside of first large chunk boundary, which is ~1200
+                end=1505,
+            )
+        ],
+    )
+    full_text = " ".join(str(i) for i in range(1000))
+    max_chunk_size = 10
+    expand_chunk_task = ExpandChunks(
+        FakeRetriever(result=full_text),
+        luminous_control_model,
+        max_chunk_size=max_chunk_size,
+    )
+    res = expand_chunk_task.run(task_input, no_op_tracer)
+    assert len(res.chunks) > 0
+    assert len(res.chunks[0].chunk.strip().split(" ")) == max_chunk_size

--- a/tests/examples/search/test_expand_chunk.py
+++ b/tests/examples/search/test_expand_chunk.py
@@ -4,17 +4,13 @@ from typing import Optional, Sequence
 from pytest import fixture
 
 from intelligence_layer.connectors import (
+    BaseRetriever,
     Document,
     DocumentChunk,
-    QdrantInMemoryRetriever,
-)
-from intelligence_layer.connectors.document_index.document_index import DocumentPath
-from intelligence_layer.connectors.retrievers.base_retriever import (
-    BaseRetriever,
-    SearchResult,
-)
-from intelligence_layer.connectors.retrievers.document_index_retriever import (
     DocumentIndexRetriever,
+    DocumentPath,
+    QdrantInMemoryRetriever,
+    SearchResult,
 )
 from intelligence_layer.core import LuminousControlModel, NoOpTracer
 from intelligence_layer.examples import ExpandChunks, ExpandChunksInput


### PR DESCRIPTION
# Description
Fixes an issue where indices were not properly passed when sub-chunking a text that started in the middle of a different text
## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
