### PR TITLE
fix: lru_cache memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
  - Add `eot_token` property to `ControlModel` and derived classes (`LuminousControlModel`, `Llama2InstructModel` and `Llama3InstructModel`) and let `PromptBasedClassify` use this property instead of a hardcoded string.
 
 ### Fixes
-...
+ - Reinitializing different `AlephAlphaModel` instances and retrieving their tokenizer should now consume a lot less memory.
 
 ### Deprecations
 ...

--- a/src/intelligence_layer/evaluation/aggregation/aggregator.py
+++ b/src/intelligence_layer/evaluation/aggregation/aggregator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from functools import lru_cache
+from functools import cached_property
 from typing import (
     Callable,
     Generic,
@@ -108,7 +108,7 @@ class Aggregator(Generic[Evaluation, AggregatedEvaluation]):
         self._aggregation_logic = aggregation_logic
         self.description = description
 
-    @lru_cache(maxsize=1)
+    @cached_property
     def _get_types(self) -> Mapping[str, type]:
         """Type magic function that gets the actual types of the generic parameters.
 
@@ -173,7 +173,7 @@ class Aggregator(Generic[Evaluation, AggregatedEvaluation]):
             Returns the type of the evaluation result of an example.
         """
         try:
-            evaluation_type = self._get_types()["Evaluation"]
+            evaluation_type = self._get_types["Evaluation"]
         except KeyError:
             raise TypeError(
                 f"Alternatively overwrite evaluation_type() in {type(self)}"

--- a/src/intelligence_layer/evaluation/evaluation/evaluator/base_evaluator.py
+++ b/src/intelligence_layer/evaluation/evaluation/evaluator/base_evaluator.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from functools import lru_cache
+from functools import cached_property
 from typing import (
     Generic,
     Iterable,
@@ -73,7 +73,7 @@ class EvaluatorBase(Generic[Input, Output, ExpectedOutput, Evaluation], ABC):
 
         self.description = description
 
-    @lru_cache(maxsize=1)
+    @cached_property
     def _get_types(self) -> Mapping[str, type]:
         """Type magic function that gets the actual types of the generic parameters.
 
@@ -137,7 +137,7 @@ class EvaluatorBase(Generic[Input, Output, ExpectedOutput, Evaluation], ABC):
             The type of the evaluated task's input.
         """
         try:
-            input_type = self._get_types()["Input"]
+            input_type = self._get_types["Input"]
         except KeyError:
             raise TypeError(f"Alternatively overwrite input_type() in {type(self)}")
         return cast(type[Input], input_type)
@@ -152,7 +152,7 @@ class EvaluatorBase(Generic[Input, Output, ExpectedOutput, Evaluation], ABC):
             The type of the evaluated task's output.
         """
         try:
-            output_type = self._get_types()["Output"]
+            output_type = self._get_types["Output"]
         except KeyError:
             raise TypeError(f"Alternatively overwrite output_type() in {type(self)}")
         return cast(type[Output], output_type)
@@ -167,7 +167,7 @@ class EvaluatorBase(Generic[Input, Output, ExpectedOutput, Evaluation], ABC):
             The type of the evaluated task's expected output.
         """
         try:
-            expected_output_type = self._get_types()["ExpectedOutput"]
+            expected_output_type = self._get_types["ExpectedOutput"]
         except KeyError:
             raise TypeError(
                 f"Alternatively overwrite expected_output_type() in {type(self)}"
@@ -184,7 +184,7 @@ class EvaluatorBase(Generic[Input, Output, ExpectedOutput, Evaluation], ABC):
             Returns the type of the evaluation result of an example.
         """
         try:
-            evaluation_type = self._get_types()["Evaluation"]
+            evaluation_type = self._get_types["Evaluation"]
         except KeyError:
             raise TypeError(
                 f"Alternatively overwrite evaluation_type() in {type(self)}"

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from aleph_alpha_client import Prompt, PromptGranularity, Text
 from pytest import fixture
@@ -111,3 +113,24 @@ def test_models_warn_about_non_recommended_models(
 
     with pytest.warns(UserWarning):
         assert AlephAlphaModel(client=client, name="No model")  # type: ignore
+
+
+def test_tokenizer_caching_works(
+    client: AlephAlphaClientProtocol,
+) -> None:
+    test = AlephAlphaModel("luminous-supreme-control")
+    start = time.time()
+    test.get_tokenizer()
+    end = time.time()
+    assert end - start > 0.1
+
+    start = time.time()
+    test.get_tokenizer()
+    end = time.time()
+    assert end - start < 0.001
+    # still fast even with new instance
+    test = AlephAlphaModel("luminous-supreme-control")
+    start = time.time()
+    test.get_tokenizer()
+    end = time.time()
+    assert end - start < 0.001

--- a/tests/evaluation/evaluation/test_evaluator.py
+++ b/tests/evaluation/evaluation/test_evaluator.py
@@ -601,7 +601,7 @@ def test_evaluator_type_magic_works(
         "dummy",
         evaluation_logic=GreatGrandChildEvaluationLogic(),
     )
-    who_is_timmy = timmy._get_types()
+    who_is_timmy = timmy._get_types
 
     assert who_is_timmy == types
 
@@ -636,7 +636,7 @@ def test_aggregator_type_magic_works(
         "dummy",
         aggregation_logic=GrandChildAggregationLogic(),
     )
-    who_is_timmy = timmy._get_types()
+    who_is_timmy = timmy._get_types
 
     assert who_is_timmy == types
 


### PR DESCRIPTION
# Description
LRU cache on self methods are very much not recommended and can lead to significant memory consumptions. Therefore, we need to replace them

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
