### PR TITLE
fix: Add comment to how_to_implement_a_task to not use custom PromptT…

### DIFF
--- a/src/documentation/how_tos/how_to_implement_a_task.ipynb
+++ b/src/documentation/how_tos/how_to_implement_a_task.ipynb
@@ -32,6 +32,7 @@
     "   1. Pass the Model to the constructor \n",
     "   2. Implement your domain logic in `do_run()`\n",
     "      1. Generate a `Prompt`. Examples for generating prompts are `ControlModel.to_instruct_prompt()`, `PromptTemplate.to_rich_prompt()` or `Prompt.from_text()`\n",
+    "         - We recommend to not write custom `PromptTemplate`s. If necessary, look up the documentation of `PromptTemplate`\n",
     "      2. Run the model with the prompt\n",
     "      3. Map the prompt output to the task output class\n",
     "3. Run and test it"


### PR DESCRIPTION
…emplate

# Description
No description.

## Before Merging
 - [ ] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [ ] Update `changelog.md` if necessary
 - [ ] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
