### PR TITLE
fix: Corrected docstrings for 'calculate_bleu'-function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ...
 
 ### Fixes
-- Reverted a bug introduced in `MultipleChunkRetrieverQa` text highlighting.
+- Update docstrings for 'calculate_bleu' in 'BleuGrader' to now correctly reflect float range from 0 to 100 for the return value.
 
 ### Deprecations 
 ...

--- a/src/intelligence_layer/evaluation/evaluation/graders.py
+++ b/src/intelligence_layer/evaluation/evaluation/graders.py
@@ -22,7 +22,7 @@ class BleuGrader:
             reference: The baseline for the evaluation.
 
         Returns:
-            BLEU-score, float between 0 and 1. Where 1 means perfect match and 0 no overlap.
+            BLEU-score, float between 0 and 100. Where 100 means perfect match and 0 no overlap.
         """
         bleu_score = self.bleu.corpus_score(
             hypotheses=[hypothesis], references=[[reference]]


### PR DESCRIPTION
…rrect float range of score

TASK: PHS-675

# Description
No description.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
