### PR TITLE
[DI-133] feat(document-index): integrate chunk overlap config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 - Add `StudioClient` as connector to PhariaStudio for submitting traces.
+- You can now specify a `chunk_overlap` when creating an index in the Document Index.
 
 ### Fixes
 ...


### PR DESCRIPTION
# Description
- you can now specify a chunk overlap when configuring an index
- add validation to ensure 0 <= overlap < chunk_size
- add validation to ensure chunk_size is specified and valid

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
