### PR TITLE
[DI-133] docs(document-index): add indexes to notebook

### DIFF
--- a/src/documentation/document_index.ipynb
+++ b/src/documentation/document_index.ipynb
@@ -19,6 +19,8 @@
     "    DocumentIndexClient,\n",
     "    DocumentIndexRetriever,\n",
     "    DocumentPath,\n",
+    "    IndexConfiguration,\n",
+    "    IndexPath,\n",
     "    LimitedConcurrencyClient,\n",
     ")\n",
     "from intelligence_layer.core import InMemoryTracer\n",
@@ -58,7 +60,7 @@
     "## Upload documents to the Document Index\n",
     "\n",
     "To search through the DI, you'll first need to upload the documents to it.\n",
-    "For now, we'll use the DI instance stored in the Aleph Alpha cloud.\n",
+    "For now, we'll use the [DI instance hosted by Aleph Alpha](https://app.document-index.aleph-alpha.com).\n",
     "We assume you have an assigned namespace and possess a token to access it."
    ]
   },
@@ -88,12 +90,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, to start working with the DI, you need to execute four simple steps:\n",
+    "Now, to start working with the DI, you need to execute five simple steps:\n",
     "\n",
-    "1. Create a collection.\n",
-    "2. Define a few documents we will put in our collection.\n",
-    "3. Upload the documents to the collection.\n",
-    "4. Verify whether the documents are successfully uploaded."
+    "1. Create a new collection.\n",
+    "2. Assign an index to the collection. This makes it searchable.\n",
+    "3. Define a few documents we will put in our collection.\n",
+    "4. Upload the documents to the collection.\n",
+    "5. Verify that the documents are successfully uploaded."
    ]
   },
   {
@@ -103,11 +106,41 @@
    "outputs": [],
    "source": [
     "# change this value if you want to use a collection of a different name\n",
-    "COLLECTION = \"demo\"\n",
+    "COLLECTION = \"intelligence-layer-sdk-demo-collection\"\n",
     "\n",
     "collection_path = CollectionPath(namespace=NAMESPACE, collection=COLLECTION)\n",
     "\n",
     "document_index.create_collection(collection_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's create an index and assign it to this collection. You can do this before or after populating the collection with documents; the Document Index automatically updates semantic indexes in the background."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# change this value if you want to use an index of a different name\n",
+    "INDEX = \"intelligence-layer-sdk-demo-index\"\n",
+    "\n",
+    "index_path = IndexPath(namespace=NAMESPACE, index=INDEX)\n",
+    "\n",
+    "# customise the parameters of the index here\n",
+    "index_configuration = IndexConfiguration(\n",
+    "    chunk_size=64, chunk_overlap=0, embedding_type=\"asymmetric\"\n",
+    ")\n",
+    "\n",
+    "# create the namespace-wide index resource\n",
+    "document_index.create_index(index_path, index_configuration)\n",
+    "\n",
+    "# assign the index to the collection\n",
+    "document_index.assign_index_to_collection(collection_path, INDEX)"
    ]
   },
   {
@@ -246,7 +279,7 @@
    "source": [
     "document_index_retriever = DocumentIndexRetriever(\n",
     "    document_index=document_index,\n",
-    "    index_name=\"asymmetric\",\n",
+    "    index_name=INDEX,\n",
     "    namespace=NAMESPACE,\n",
     "    collection=COLLECTION,\n",
     "    k=5,\n",
@@ -323,7 +356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description
- update Document Index jupyter notebook to include creation and assignment of index
- make default collection and index names less generic

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
