### PR TITLE
vsp  - optional explainability in qa tasks per run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@
   - Introducing `Llama3ChatModel` for usage with llama models.
 - Upgrade `ArgillaWrapperClient` to use Argilla v2.0.1
 - (Beta) Add `DataClient` and `StudioDatasetRepository` as connectors to Studio for submitting data.
+- Add the optional argument `generate_highlights` to `MultiChunkQa`, `RetrieverBasedQa` and `SingleChunkQa`. This makes it possible to disable highlighting for performance reasons.
 
 ### Fixes
-- increase number of returned `log_probs` in `EloQaEvaluationLogic` to avoid missing a valid answer
+- Increase number of returned `log_probs` in `EloQaEvaluationLogic` to avoid missing a valid answer
 
 ### Deprecations 
 - Removed `DefaultArgillaClient`

--- a/src/documentation/qa.ipynb
+++ b/src/documentation/qa.ipynb
@@ -94,7 +94,7 @@
     "question = \"What are some benefits of surface micro-machining?\"\n",
     "\n",
     "# Pass both the input text and the question to the SingleChunkQaInput-task\n",
-    "input = SingleChunkQaInput(chunk=text, question=question, explainability_enabled=True)\n",
+    "input = SingleChunkQaInput(chunk=text, question=question, generate_highlights=True)\n",
     "\n",
     "# Define a LuminousControlModel and instantiate a SingleChunkQa task\n",
     "model = LuminousControlModel(name=\"luminous-supreme-control\")\n",

--- a/src/documentation/qa.ipynb
+++ b/src/documentation/qa.ipynb
@@ -94,7 +94,7 @@
     "question = \"What are some benefits of surface micro-machining?\"\n",
     "\n",
     "# Pass both the input text and the question to the SingleChunkQaInput-task\n",
-    "input = SingleChunkQaInput(chunk=text, question=question)\n",
+    "input = SingleChunkQaInput(chunk=text, question=question, explainability_enabled=True)\n",
     "\n",
     "# Define a LuminousControlModel and instantiate a SingleChunkQa task\n",
     "model = LuminousControlModel(name=\"luminous-supreme-control\")\n",

--- a/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
@@ -29,7 +29,7 @@ class MultipleChunkQaInput(BaseModel):
             Can be arbitrarily long list of chunks.
         question: The question that will be answered based on the chunks.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer.  Defaults to `False` for performance reasons.
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer.  Defaults to `True`.
     """
 
     chunks: Sequence[TextChunk]

--- a/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
@@ -29,11 +29,13 @@ class MultipleChunkQaInput(BaseModel):
             Can be arbitrarily long list of chunks.
         question: The question that will be answered based on the chunks.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
+        explainability_enabled: Whether to generate highlights (using the explainability feature) for the answer;  default False for performance reasons
     """
 
     chunks: Sequence[TextChunk]
     question: str
     language: Language = Language("en")
+    explainability_enabled: bool = False
 
 
 class Subanswer(BaseModel):
@@ -184,7 +186,7 @@ class MultipleChunkQa(Task[MultipleChunkQaInput, MultipleChunkQaOutput]):
         qa_outputs = self._single_chunk_qa.run_concurrently(
             (
                 SingleChunkQaInput(
-                    question=input.question, chunk=chunk, language=input.language
+                    question=input.question, chunk=chunk, language=input.language, explainability_enabled=input.explainability_enabled
                 )
                 for chunk in input.chunks
             ),

--- a/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
@@ -186,7 +186,10 @@ class MultipleChunkQa(Task[MultipleChunkQaInput, MultipleChunkQaOutput]):
         qa_outputs = self._single_chunk_qa.run_concurrently(
             (
                 SingleChunkQaInput(
-                    question=input.question, chunk=chunk, language=input.language, explainability_enabled=input.explainability_enabled
+                    question=input.question,
+                    chunk=chunk,
+                    language=input.language,
+                    explainability_enabled=input.explainability_enabled,
                 )
                 for chunk in input.chunks
             ),

--- a/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
@@ -29,13 +29,13 @@ class MultipleChunkQaInput(BaseModel):
             Can be arbitrarily long list of chunks.
         question: The question that will be answered based on the chunks.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        explainability_enabled: Whether to generate highlights (using the explainability feature) for the answer;  default False for performance reasons
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer;  default False for performance reasons
     """
 
     chunks: Sequence[TextChunk]
     question: str
     language: Language = Language("en")
-    explainability_enabled: bool = True
+    generate_highlights: bool = True
 
 
 class Subanswer(BaseModel):
@@ -189,7 +189,7 @@ class MultipleChunkQa(Task[MultipleChunkQaInput, MultipleChunkQaOutput]):
                     question=input.question,
                     chunk=chunk,
                     language=input.language,
-                    explainability_enabled=input.explainability_enabled,
+                    generate_highlights=input.generate_highlights,
                 )
                 for chunk in input.chunks
             ),

--- a/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
@@ -29,7 +29,7 @@ class MultipleChunkQaInput(BaseModel):
             Can be arbitrarily long list of chunks.
         question: The question that will be answered based on the chunks.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer;  default False for performance reasons
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer.  Defaults to `False` for performance reasons.
     """
 
     chunks: Sequence[TextChunk]

--- a/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/multiple_chunk_qa.py
@@ -35,7 +35,7 @@ class MultipleChunkQaInput(BaseModel):
     chunks: Sequence[TextChunk]
     question: str
     language: Language = Language("en")
-    explainability_enabled: bool = False
+    explainability_enabled: bool = True
 
 
 class Subanswer(BaseModel):

--- a/src/intelligence_layer/examples/qa/multiple_chunk_retriever_qa.py
+++ b/src/intelligence_layer/examples/qa/multiple_chunk_retriever_qa.py
@@ -125,7 +125,7 @@ class MultipleChunkRetrieverQa(
             chunk=chunk_for_prompt,
             question=input.question,
             language=input.language,
-            explainability_enabled=input.explainability_enabled,
+            generate_highlights=input.generate_highlights,
         )
 
         single_chunk_qa_output = self._single_chunk_qa.run(

--- a/src/intelligence_layer/examples/qa/multiple_chunk_retriever_qa.py
+++ b/src/intelligence_layer/examples/qa/multiple_chunk_retriever_qa.py
@@ -125,6 +125,7 @@ class MultipleChunkRetrieverQa(
             chunk=chunk_for_prompt,
             question=input.question,
             language=input.language,
+            explainability_enabled=input.explainability_enabled,
         )
 
         single_chunk_qa_output = self._single_chunk_qa.run(

--- a/src/intelligence_layer/examples/qa/retriever_based_qa.py
+++ b/src/intelligence_layer/examples/qa/retriever_based_qa.py
@@ -22,7 +22,7 @@ class RetrieverBasedQaInput(BaseModel):
         question: The question to be answered based on the documents accessed
             by the retriever.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer. Defaults to `False` for performance reasons.
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer. Defaults to `True`.
     """
 
     question: str

--- a/src/intelligence_layer/examples/qa/retriever_based_qa.py
+++ b/src/intelligence_layer/examples/qa/retriever_based_qa.py
@@ -22,12 +22,12 @@ class RetrieverBasedQaInput(BaseModel):
         question: The question to be answered based on the documents accessed
             by the retriever.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        explainability_enabled: Whether to generate highlights (using the explainability feature) for the answer; default False for performance reasons.
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer; default False for performance reasons.
     """
 
     question: str
     language: Language = Language("en")
-    explainability_enabled: bool = True
+    generate_highlights: bool = True
 
 
 class EnrichedSubanswer(Subanswer, Generic[ID]):
@@ -119,7 +119,7 @@ class RetrieverBasedQa(
             ],
             question=input.question,
             language=input.language,
-            explainability_enabled=input.explainability_enabled,
+            generate_highlights=input.generate_highlights,
         )
 
         multi_chunk_qa_output = self._multi_chunk_qa.run(

--- a/src/intelligence_layer/examples/qa/retriever_based_qa.py
+++ b/src/intelligence_layer/examples/qa/retriever_based_qa.py
@@ -27,7 +27,7 @@ class RetrieverBasedQaInput(BaseModel):
 
     question: str
     language: Language = Language("en")
-    explainability_enabled: bool = False
+    explainability_enabled: bool = True
 
 
 class EnrichedSubanswer(Subanswer, Generic[ID]):

--- a/src/intelligence_layer/examples/qa/retriever_based_qa.py
+++ b/src/intelligence_layer/examples/qa/retriever_based_qa.py
@@ -22,10 +22,12 @@ class RetrieverBasedQaInput(BaseModel):
         question: The question to be answered based on the documents accessed
             by the retriever.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
+        explainability_enabled: Whether to generate highlights (using the explainability feature) for the answer; default False for performance reasons.
     """
 
     question: str
     language: Language = Language("en")
+    explainability_enabled: bool = False
 
 
 class EnrichedSubanswer(Subanswer, Generic[ID]):
@@ -117,6 +119,7 @@ class RetrieverBasedQa(
             ],
             question=input.question,
             language=input.language,
+            explainability_enabled=input.explainability_enabled,
         )
 
         multi_chunk_qa_output = self._multi_chunk_qa.run(

--- a/src/intelligence_layer/examples/qa/retriever_based_qa.py
+++ b/src/intelligence_layer/examples/qa/retriever_based_qa.py
@@ -22,7 +22,7 @@ class RetrieverBasedQaInput(BaseModel):
         question: The question to be answered based on the documents accessed
             by the retriever.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer; default False for performance reasons.
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer. Defaults to `False` for performance reasons.
     """
 
     question: str

--- a/src/intelligence_layer/examples/qa/single_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/single_chunk_qa.py
@@ -62,7 +62,7 @@ class SingleChunkQaInput(BaseModel):
             Can't be longer than the context length of the model used minus the size of the system prompt.
         question: The question to be asked by about the chunk.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer; default False for performance reasons
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer. Defaults to `False` for performance reasons.
     """
 
     chunk: TextChunk

--- a/src/intelligence_layer/examples/qa/single_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/single_chunk_qa.py
@@ -156,9 +156,6 @@ class SingleChunkQa(Task[SingleChunkQaInput, SingleChunkQaOutput]):
         answer = self._no_answer_to_none(
             output.completion.strip(), qa_setup.no_answer_str
         )
-        print("!!!!!!!!!!!!!!!!")
-        print(input.explainability_enabled)
-        print("!!!!!!!!!!!!!!!!")
         if input.explainability_enabled:
             raw_highlights = (
                 self._get_highlights(

--- a/src/intelligence_layer/examples/qa/single_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/single_chunk_qa.py
@@ -68,7 +68,7 @@ class SingleChunkQaInput(BaseModel):
     chunk: TextChunk
     question: str
     language: Language = Language("en")
-    explainability_enabled: bool = False
+    explainability_enabled: bool = True
 
 
 class SingleChunkQaOutput(BaseModel):

--- a/src/intelligence_layer/examples/qa/single_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/single_chunk_qa.py
@@ -62,7 +62,7 @@ class SingleChunkQaInput(BaseModel):
             Can't be longer than the context length of the model used minus the size of the system prompt.
         question: The question to be asked by about the chunk.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer. Defaults to `False` for performance reasons.
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer. Defaults to `True`.
     """
 
     chunk: TextChunk

--- a/src/intelligence_layer/examples/qa/single_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/single_chunk_qa.py
@@ -62,13 +62,13 @@ class SingleChunkQaInput(BaseModel):
             Can't be longer than the context length of the model used minus the size of the system prompt.
         question: The question to be asked by about the chunk.
         language: The desired language of the answer. ISO 619 str with language e.g. en, fr, etc.
-        explainability_enabled: Whether to generate highlights (using the explainability feature) for the answer; default False for performance reasons
+        generate_highlights: Whether to generate highlights (using the explainability feature) for the answer; default False for performance reasons
     """
 
     chunk: TextChunk
     question: str
     language: Language = Language("en")
-    explainability_enabled: bool = True
+    generate_highlights: bool = True
 
 
 class SingleChunkQaOutput(BaseModel):
@@ -157,7 +157,7 @@ class SingleChunkQa(Task[SingleChunkQaInput, SingleChunkQaOutput]):
         answer = self._no_answer_to_none(
             output.completion.strip(), qa_setup.no_answer_str
         )
-        if input.explainability_enabled:
+        if input.generate_highlights:
             raw_highlights = (
                 self._get_highlights(
                     prompt,

--- a/src/intelligence_layer/examples/qa/single_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/single_chunk_qa.py
@@ -156,6 +156,9 @@ class SingleChunkQa(Task[SingleChunkQaInput, SingleChunkQaOutput]):
         answer = self._no_answer_to_none(
             output.completion.strip(), qa_setup.no_answer_str
         )
+        print("!!!!!!!!!!!!!!!!")
+        print(input.explainability_enabled)
+        print("!!!!!!!!!!!!!!!!")
         if input.explainability_enabled:
             raw_highlights = (
                 self._get_highlights(

--- a/src/intelligence_layer/examples/qa/single_chunk_qa.py
+++ b/src/intelligence_layer/examples/qa/single_chunk_qa.py
@@ -70,6 +70,7 @@ class SingleChunkQaInput(BaseModel):
     language: Language = Language("en")
     explainability_enabled: bool = False
 
+
 class SingleChunkQaOutput(BaseModel):
     """The output of a `SingleChunkQa` task.
 

--- a/tests/examples/qa/test_multiple_chunk_qa.py
+++ b/tests/examples/qa/test_multiple_chunk_qa.py
@@ -32,7 +32,7 @@ def test_multiple_chunk_qa_with_mulitple_chunks(
     ]
 
     input = MultipleChunkQaInput(
-        chunks=chunks, question=RELATED_QUESTION, explainability_enabled=True
+        chunks=chunks, question=RELATED_QUESTION, generate_highlights=True
     )
     output = multiple_chunk_qa.run(input, NoOpTracer())
 
@@ -56,7 +56,7 @@ def test_multiple_chunk_qa_with_mulitple_chunks_explainability_disabled(
     ]
 
     input = MultipleChunkQaInput(
-        chunks=chunks, question=RELATED_QUESTION, explainability_enabled=False
+        chunks=chunks, question=RELATED_QUESTION, generate_highlights=False
     )
     output = multiple_chunk_qa.run(input, NoOpTracer())
 

--- a/tests/examples/qa/test_multiple_chunk_qa.py
+++ b/tests/examples/qa/test_multiple_chunk_qa.py
@@ -64,7 +64,7 @@ def test_multiple_chunk_qa_with_mulitple_chunks_explainability_disabled(
     assert IMPORTANT_PART_OF_CORRECT_ANSWER in output.answer
     assert len(output.subanswers) == 1
     assert output.subanswers[0].chunk == chunks[0]
-    assert all(highlight == [] for highlight in output.subanswers[0].highlights)
+    assert all(len(highlight) == 0 for highlight in output.highlights)
 
 
 def test_multiple_chunk_qa_without_answer(multiple_chunk_qa: MultipleChunkQa) -> None:

--- a/tests/examples/qa/test_multiple_chunk_qa.py
+++ b/tests/examples/qa/test_multiple_chunk_qa.py
@@ -31,7 +31,7 @@ def test_multiple_chunk_qa_with_mulitple_chunks(
         RELATED_CHUNK_WITHOUT_ANSWER,
     ]
 
-    input = MultipleChunkQaInput(chunks=chunks, question=RELATED_QUESTION)
+    input = MultipleChunkQaInput(chunks=chunks, question=RELATED_QUESTION, explainability_enabled=True)
     output = multiple_chunk_qa.run(input, NoOpTracer())
 
     assert output.answer

--- a/tests/examples/qa/test_multiple_chunk_qa.py
+++ b/tests/examples/qa/test_multiple_chunk_qa.py
@@ -64,7 +64,7 @@ def test_multiple_chunk_qa_with_mulitple_chunks_explainability_disabled(
     assert IMPORTANT_PART_OF_CORRECT_ANSWER in output.answer
     assert len(output.subanswers) == 1
     assert output.subanswers[0].chunk == chunks[0]
-    assert all(len(highlight) == 0 for highlight in output.highlights)
+    assert all(not subanswer.highlights for subanswer in output.subanswers)
 
 
 def test_multiple_chunk_qa_without_answer(multiple_chunk_qa: MultipleChunkQa) -> None:

--- a/tests/examples/qa/test_multiple_chunk_qa.py
+++ b/tests/examples/qa/test_multiple_chunk_qa.py
@@ -31,7 +31,9 @@ def test_multiple_chunk_qa_with_mulitple_chunks(
         RELATED_CHUNK_WITHOUT_ANSWER,
     ]
 
-    input = MultipleChunkQaInput(chunks=chunks, question=RELATED_QUESTION, explainability_enabled=True)
+    input = MultipleChunkQaInput(
+        chunks=chunks, question=RELATED_QUESTION, explainability_enabled=True
+    )
     output = multiple_chunk_qa.run(input, NoOpTracer())
 
     assert output.answer

--- a/tests/examples/qa/test_multiple_chunk_qa.py
+++ b/tests/examples/qa/test_multiple_chunk_qa.py
@@ -47,6 +47,26 @@ def test_multiple_chunk_qa_with_mulitple_chunks(
     )
 
 
+def test_multiple_chunk_qa_with_mulitple_chunks_explainability_disabled(
+    multiple_chunk_qa: MultipleChunkQa,
+) -> None:
+    chunks: Sequence[TextChunk] = [
+        CHUNK_CONTAINING_ANSWER,
+        RELATED_CHUNK_WITHOUT_ANSWER,
+    ]
+
+    input = MultipleChunkQaInput(
+        chunks=chunks, question=RELATED_QUESTION, explainability_enabled=False
+    )
+    output = multiple_chunk_qa.run(input, NoOpTracer())
+
+    assert output.answer
+    assert IMPORTANT_PART_OF_CORRECT_ANSWER in output.answer
+    assert len(output.subanswers) == 1
+    assert output.subanswers[0].chunk == chunks[0]
+    assert all(highlight == [] for highlight in output.subanswers[0].highlights)
+
+
 def test_multiple_chunk_qa_without_answer(multiple_chunk_qa: MultipleChunkQa) -> None:
     chunks: Sequence[TextChunk] = [CHUNK_CONTAINING_ANSWER]
 

--- a/tests/examples/qa/test_single_chunk_qa.py
+++ b/tests/examples/qa/test_single_chunk_qa.py
@@ -21,6 +21,7 @@ def test_qa_with_answer(single_chunk_qa: SingleChunkQa) -> None:
         chunk=TextChunk(input_text),
         question="What is the name of Paul Nicolas' brother?",
         language=Language("en"),
+        explainability_enabled=True
     )
     output = single_chunk_qa.run(input, NoOpTracer())
 

--- a/tests/examples/qa/test_single_chunk_qa.py
+++ b/tests/examples/qa/test_single_chunk_qa.py
@@ -21,7 +21,7 @@ def test_qa_with_answer(single_chunk_qa: SingleChunkQa) -> None:
         chunk=TextChunk(input_text),
         question="What is the name of Paul Nicolas' brother?",
         language=Language("en"),
-        explainability_enabled=True,
+        generate_highlights=True,
     )
     output = single_chunk_qa.run(input, NoOpTracer())
 
@@ -39,7 +39,7 @@ def test_qa_with_answer_explainability_disabled(single_chunk_qa: SingleChunkQa) 
         chunk=TextChunk(input_text),
         question="What is the name of Paul Nicolas' brother?",
         language=Language("en"),
-        explainability_enabled=False,
+        generate_highlights=False,
     )
     output = single_chunk_qa.run(input, NoOpTracer())
 

--- a/tests/examples/qa/test_single_chunk_qa.py
+++ b/tests/examples/qa/test_single_chunk_qa.py
@@ -45,7 +45,7 @@ def test_qa_with_answer_explainability_disabled(single_chunk_qa: SingleChunkQa) 
 
     assert output.answer
     assert "Henri" in output.answer
-    assert all(highlight == [] for highlight in output.highlights)
+    assert all(len(highlight) == 0 for highlight in output.highlights)
 
 
 def test_qa_with_no_answer(single_chunk_qa: SingleChunkQa) -> None:

--- a/tests/examples/qa/test_single_chunk_qa.py
+++ b/tests/examples/qa/test_single_chunk_qa.py
@@ -33,6 +33,21 @@ def test_qa_with_answer(single_chunk_qa: SingleChunkQa) -> None:
     )
 
 
+def test_qa_with_answer_explainability_disabled(single_chunk_qa: SingleChunkQa) -> None:
+    input_text = "Paul Nicolas lost his mother at the age of 3, and then his father in 1914.[3] He was raised by his mother-in-law together with his brother Henri. He began his football career with Saint-Mandé Club in 1916. Initially, he played as a defender, but he quickly realized that his destiny laid at the forefront since he scored many goals.[3] In addition to his goal-scoring instinct, Nicolas also stood out for his strong character on the pitch, and these two qualities combined eventually drew the attention of Mr. Fort, the then president of the Gallia Club, who signed him as a centre-forward in 1916."
+    input = SingleChunkQaInput(
+        chunk=TextChunk(input_text),
+        question="What is the name of Paul Nicolas' brother?",
+        language=Language("en"),
+        explainability_enabled=False,
+    )
+    output = single_chunk_qa.run(input, NoOpTracer())
+
+    assert output.answer
+    assert "Henri" in output.answer
+    assert all(highlight == [] for highlight in output.highlights)
+
+
 def test_qa_with_no_answer(single_chunk_qa: SingleChunkQa) -> None:
     input = SingleChunkQaInput(
         chunk=TextChunk(

--- a/tests/examples/qa/test_single_chunk_qa.py
+++ b/tests/examples/qa/test_single_chunk_qa.py
@@ -21,7 +21,7 @@ def test_qa_with_answer(single_chunk_qa: SingleChunkQa) -> None:
         chunk=TextChunk(input_text),
         question="What is the name of Paul Nicolas' brother?",
         language=Language("en"),
-        explainability_enabled=True
+        explainability_enabled=True,
     )
     output = single_chunk_qa.run(input, NoOpTracer())
 

--- a/tests/examples/qa/test_single_chunk_qa.py
+++ b/tests/examples/qa/test_single_chunk_qa.py
@@ -45,7 +45,7 @@ def test_qa_with_answer_explainability_disabled(single_chunk_qa: SingleChunkQa) 
 
     assert output.answer
     assert "Henri" in output.answer
-    assert all(len(highlight) == 0 for highlight in output.highlights)
+    assert not output.highlights
 
 
 def test_qa_with_no_answer(single_chunk_qa: SingleChunkQa) -> None:


### PR DESCRIPTION
# Description
No description.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [ ] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
