### PR TITLE
fix(document-index): use chunk overlap when creating a new index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 - You can now specify a `hybrid_index` when creating an index for the document index to use hybrid (semantic and keyword) search.
 - `min_score` and `max_results` are now optional parameters in `DocumentIndexClient.SearchQuery`.
 - `k` is now an optional parameter in `DocumentIndexRetriever`.
+- List all indexes of a namespace with `DocumentIndexClient.list_indexes`.
+- Remove an index from a namespace with `DocumentIndexClient.delete_index`.
 
 ### Fixes
-...
+- `DocumentIndexClient` now properly sets `chunk_overlap` when creating an index configuration.
+
 ### Deprecations 
 ...
 ### Breaking Changes


### PR DESCRIPTION
# Description
No description.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
