### PR TITLE
[DI-206] feat: make Document Index search parameters optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 ## Unreleased
 ### Features
-...
+- `min_score` and `max_results` are now optional parameters in `DocumentIndexClient.SearchQuery`.
+- `k` is now an optional parameter in `DocumentIndexRetriever`.
+
 ### Fixes
 ...
 ### Deprecations 
 ...
 ### Breaking Changes
-...
+- The default value of `threshold` in the `DocumentIndexRetriever` has changed from `0.5` to `0.0`. This accommodates fusion scoring for searches over hybrid indexes.
+
 
 ## 6.0.0
 
@@ -21,8 +24,6 @@
 - Upgrade `ArgillaWrapperClient` to use Argilla v2.x
 - (Beta) Add `DataClient` and `StudioDatasetRepository` as connectors to Studio for submitting data.
 - Add the optional argument `generate_highlights` to `MultiChunkQa`, `RetrieverBasedQa` and `SingleChunkQa`. This makes it possible to disable highlighting for performance reasons.
-- `min_score` and `max_results` are now optional parameters in `DocumentIndexClient.SearchQuery`.
-- `k` is now an optional parameter in `DocumentIndexRetriever`.
 
 ### Fixes
 - Increase number of returned `log_probs` in `EloQaEvaluationLogic` to avoid missing a valid answer
@@ -34,7 +35,6 @@
 ### Breaking Changes
 - We needed to upgrade argilla-server image version from `argilla-server:v1.26.0` to `argilla-server:v1.29.0` to maintain compatibility.
   - Note: We also updated our elasticsearch argilla backend to `8.12.2`
-- The default value of `threshold` in the `DocumentIndexRetriever` is now `0.0`. This accommodates fusion scoring for searches over hybrid indexes.
 
 
 ## 5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Upgrade `ArgillaWrapperClient` to use Argilla v2.x
 - (Beta) Add `DataClient` and `StudioDatasetRepository` as connectors to Studio for submitting data.
 - Add the optional argument `generate_highlights` to `MultiChunkQa`, `RetrieverBasedQa` and `SingleChunkQa`. This makes it possible to disable highlighting for performance reasons.
+- `min_score` and `max_results` are now optional parameters in `DocumentIndexClient.SearchQuery`.
+- `k` is now an optional parameter in `DocumentIndexRetriever`.
 
 ### Fixes
 - Increase number of returned `log_probs` in `EloQaEvaluationLogic` to avoid missing a valid answer
@@ -32,6 +34,7 @@
 ### Breaking Changes
 - We needed to upgrade argilla-server image version from `argilla-server:v1.26.0` to `argilla-server:v1.29.0` to maintain compatibility.
   - Note: We also updated our elasticsearch argilla backend to `8.12.2`
+- The default value of `threshold` in the `DocumentIndexRetriever` is now `0.0`. This accommodates fusion scoring for searches over hybrid indexes.
 
 
 ## 5.1.0

--- a/src/documentation/document_index.ipynb
+++ b/src/documentation/document_index.ipynb
@@ -283,7 +283,6 @@
     "    namespace=NAMESPACE,\n",
     "    collection=COLLECTION,\n",
     "    k=5,\n",
-    "    threshold=0.5,\n",
     ")\n",
     "\n",
     "document_index_retriever.get_relevant_documents_with_scores(\n",
@@ -402,7 +401,6 @@
     "    namespace=NAMESPACE,\n",
     "    collection=COLLECTION,\n",
     "    k=5,\n",
-    "    threshold=0.2,\n",
     ")"
    ]
   },

--- a/src/intelligence_layer/connectors/document_index/document_index.py
+++ b/src/intelligence_layer/connectors/document_index/document_index.py
@@ -255,8 +255,8 @@ class SearchQuery(BaseModel):
     """
 
     query: str
-    max_results: int = Field(..., ge=0)
-    min_score: float = Field(..., ge=0.0, le=1.0)
+    max_results: int = Field(ge=0, default=1)
+    min_score: float = Field(ge=0.0, le=1.0, default=0.0)
     filters: Optional[list[Filters]] = None
 
 

--- a/src/intelligence_layer/connectors/retrievers/document_index_retriever.py
+++ b/src/intelligence_layer/connectors/retrievers/document_index_retriever.py
@@ -22,16 +22,6 @@ class DocumentIndexRetriever(BaseRetriever[DocumentPath]):
 
     This retriever lets you search for relevant documents in the given Document Index collection.
 
-    Args:
-        document_index: The Document Index client.
-        index_name: The name of the Document Index index to use.
-        namespace: The Document Index namespace.
-        collection: The Document Index collection to use. This is the search context for the retriever.
-        k: The number of most-relevant documents to return when searching.
-        threshold: The minimum score for search results. For semantic indexes, this is the cosine
-            similarity between the query and the document chunk. For hybrid indexes, this corresponds
-            to fusion rank.
-
     Example:
     >>> import os
     >>> from intelligence_layer.connectors import DocumentIndexClient, DocumentIndexRetriever
@@ -49,6 +39,18 @@ class DocumentIndexRetriever(BaseRetriever[DocumentPath]):
         k: int = 1,
         threshold: float = 0.0,
     ) -> None:
+        """Initialize the DocumentIndexRetriever.
+
+        Args:
+            document_index: The Document Index client.
+            index_name: The name of the Document Index index to use.
+            namespace: The Document Index namespace.
+            collection: The Document Index collection to use. This is the search context for the retriever.
+            k: The number of most-relevant documents to return when searching. Defaults to 1.
+            threshold: The minimum score for search results. For semantic indexes, this is the cosine
+                similarity between the query and the document chunk. For hybrid indexes, this corresponds
+                to fusion rank. Defaults to 0.0.
+        """
         self._document_index = document_index
         self._index_name = index_name
         self._collection_path = CollectionPath(

--- a/src/intelligence_layer/connectors/retrievers/document_index_retriever.py
+++ b/src/intelligence_layer/connectors/retrievers/document_index_retriever.py
@@ -20,16 +20,17 @@ from intelligence_layer.connectors.retrievers.base_retriever import (
 class DocumentIndexRetriever(BaseRetriever[DocumentPath]):
     """Search through documents within collections in the `DocumentIndexClient`.
 
-    We initialize this Retriever with a collection & namespace names, and we can find the documents in the collection
-    most semanticly similar to our query.
+    This retriever lets you search for relevant documents in the given Document Index collection.
 
     Args:
-        document_index: Client offering functionality for search.
-        index_name: The name of the index to be used.
-        namespace: The namespace within the `DocumentIndexClient` where all collections are stored.
-        collection: The collection within the namespace that holds the desired documents.
-        k: The (top) number of documents to be returned by search.
-        threshold: The mimumum value of cosine similarity between the query vector and the document vector.
+        document_index: The Document Index client.
+        index_name: The name of the Document Index index to use.
+        namespace: The Document Index namespace.
+        collection: The Document Index collection to use. This is the search context for the retriever.
+        k: The number of most-relevant documents to return when searching.
+        threshold: The minimum score for search results. For semantic indexes, this is the cosine
+            similarity between the query and the document chunk. For hybrid indexes, this corresponds
+            to fusion rank.
 
     Example:
     >>> import os
@@ -45,8 +46,8 @@ class DocumentIndexRetriever(BaseRetriever[DocumentPath]):
         index_name: str,
         namespace: str,
         collection: str,
-        k: int,
-        threshold: float = 0.5,
+        k: int = 1,
+        threshold: float = 0.0,
     ) -> None:
         self._document_index = document_index
         self._index_name = index_name


### PR DESCRIPTION
# Description
This commit aligns optional parameters in the IL with the Document Index API.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
