### PR TITLE
chore: remove unused type ignores

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+
+warn_unused_ignores = True

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env -S bash -eu -o pipefail
 
+cd $(dirname $0)/..
+
 poetry run pre-commit run --all-files
-poetry run mypy
+poetry run mypy .

--- a/src/intelligence_layer/evaluation/aggregation/accumulator.py
+++ b/src/intelligence_layer/evaluation/aggregation/accumulator.py
@@ -56,12 +56,10 @@ class MeanAccumulator(Accumulator[float, float]):
             return 0.0
         mean = self.extract()
         variance = (self._squares_acc / self._n) - (mean**2)
-        # not recognized as float by VSCode or mypy
-        return variance**0.5  # type: ignore
+        return variance**0.5
 
     def standard_error(self) -> float:
         """Calculates the standard error of the mean."""
         if self._n <= 1:
             return 0.0
-        # not recognized as float by VSCode or mypy
-        return self.standard_deviation() / (self._n**0.5)  # type: ignore
+        return self.standard_deviation() / (self._n**0.5)

--- a/src/intelligence_layer/evaluation/aggregation/elo_aggregation.py
+++ b/src/intelligence_layer/evaluation/aggregation/elo_aggregation.py
@@ -81,8 +81,7 @@ class EloCalculator:
 
     def _calc_k_factor(self, player: str) -> float:
         n = self._match_counts.get(player) or 0
-        # Mypy thinks this is Any
-        return self._k_ceiling * np.exp(-self._decay_factor * n) + self._k_floor  # type: ignore
+        return self._k_ceiling * np.exp(-self._decay_factor * n) + self._k_floor
 
     def _calc_expected_win_rates(
         self, player_a: str, player_b: str

--- a/src/intelligence_layer/evaluation/evaluation/graders.py
+++ b/src/intelligence_layer/evaluation/evaluation/graders.py
@@ -28,7 +28,7 @@ class BleuGrader:
             hypotheses=[hypothesis], references=[[reference]]
         )
 
-        return bleu_score.score  # type: ignore
+        return bleu_score.score
 
 
 @dataclass

--- a/src/intelligence_layer/learning/instruction_finetuning_data_handler.py
+++ b/src/intelligence_layer/learning/instruction_finetuning_data_handler.py
@@ -322,7 +322,7 @@ class InstructionFinetuningDataHandler:
             sample: InstructionFinetuningSample,
             # actual type is Synchronized[int] but declaring this will actually fail at runtime
             # only declaring Synchronized will trigger mypy
-            emitted_counter: Synchronized,  # type: ignore
+            emitted_counter: Synchronized,
             statistics_counter: dict[Any, dict[Any, int]],
         ) -> Optional[tuple[Sequence[FinetuningMessage], str]]:
             prompt = model.to_chat_prompt(sample.messages)

--- a/src/intelligence_layer/learning/instruction_finetuning_data_handler.py
+++ b/src/intelligence_layer/learning/instruction_finetuning_data_handler.py
@@ -321,7 +321,6 @@ class InstructionFinetuningDataHandler:
         def process_sample(
             sample: InstructionFinetuningSample,
             # actual type is Synchronized[int] but declaring this will actually fail at runtime
-            # only declaring Synchronized will trigger mypy
             emitted_counter: Synchronized,
             statistics_counter: dict[Any, dict[Any, int]],
         ) -> Optional[tuple[Sequence[FinetuningMessage], str]]:

--- a/tests/connectors/test_limited_concurrency_client.py
+++ b/tests/connectors/test_limited_concurrency_client.py
@@ -52,7 +52,7 @@ class BusyClient:
         if self.wait_time:
             time.sleep(self.wait_time)
         if self.number_of_retries < 2:
-            raise BusyError(503)  # type: ignore
+            raise BusyError(503)
         else:
             if isinstance(self.return_value, Exception):
                 raise self.return_value


### PR DESCRIPTION
# Description

This PR removes existing `# type: ignore` suppressions that are unnecessary. Having unused type ignores can be confusing when reading the code, and may actually lead to bugs, if they linger around and suppress a genuine bug in the future. To avoid issues caused by dead type ignores I've enabled the corresponding mypy check.

The PR also makes `lint.sh` agnostic to the current working directory (currently the linting results can differ depending on from which working directory it gets executed). 

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [ ] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
