### PR TITLE
fix: tokenizer with no whitespace prefix will no longer fail

### DIFF
--- a/src/intelligence_layer/core/model.py
+++ b/src/intelligence_layer/core/model.py
@@ -380,9 +380,7 @@ def _tokenizer_no_whitespace_prefix(
         copied_tokenizer.pre_tokenizer.add_prefix_space = False
         return copied_tokenizer
 
-    raise ValueError(
-        "Tokenizer does not support `.pre_tokenizer` and thus `.add_prefix_space` option."
-    )
+    return tokenizer
 
 
 @lru_cache(maxsize=10)


### PR DESCRIPTION
# Description
No description.

## Before Merging
 - [ ] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [ ] Update `changelog.md` if necessary
 - [ ] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
