### PR TITLE
fix: allow negative min score in SearchQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add method `DocumentIndexClient.chunks()` for retrieving all text chunks of a document.
 
 ### Fixes
-...
+- The Document Index `SearchQuery` now correctly allows searches with a negative `min_score`.
 
 ### Deprecations
 ...

--- a/src/documentation/elo_qa_eval.ipynb
+++ b/src/documentation/elo_qa_eval.ipynb
@@ -448,7 +448,7 @@
    "outputs": [],
    "source": [
     "newly_added_models = [\n",
-    "    Llama3InstructModel(name=\"llama-3.1-70b-instruct\", client=aa_client),\n",
+    "    Llama3InstructModel(name=\"llama-3.3-70b-instruct\", client=aa_client),\n",
     "]\n",
     "\n",
     "for model in newly_added_models:\n",

--- a/src/intelligence_layer/connectors/document_index/document_index.py
+++ b/src/intelligence_layer/connectors/document_index/document_index.py
@@ -293,16 +293,15 @@ class SearchQuery(BaseModel):
         query: Actual text to be searched with.
         max_results: Max number of search results to be retrieved by the query.
             Must be larger than 0.
-        min_score: Filter out results with a similarity score below this value.
-            Must be between 0 and 1.
-            For searches on hybrid indexes, the Document Index applies the min_score
-            to the semantic results before fusion of result sets. As fusion re-scores results,
+        min_score: Filter out results with a similarity score below this value. Must be between
+            -1 and 1. For searches on hybrid indexes, the Document Index applies the min_score to
+            the semantic results before fusion of result sets. As fusion re-scores results,
             returned scores may exceed this value.
     """
 
     query: str
     max_results: int = Field(ge=0, default=1)
-    min_score: float = Field(ge=0.0, le=1.0, default=0.0)
+    min_score: float = Field(ge=-1.0, le=1.0, default=0.0)
     filters: Optional[list[Filters]] = None
 
 

--- a/src/intelligence_layer/core/model.py
+++ b/src/intelligence_layer/core/model.py
@@ -261,7 +261,7 @@ class AlephAlphaModel(LanguageModel):
         )
         if name not in [model["name"] for model in self._client.models()]:
             warnings.warn(
-                "The provided model is not a recommended model for this model class."
+                "The provided model is not a recommended model for this model class. "
                 "Make sure that the model you have selected is suited to be use for the prompt template used in this model class."
             )
         self._complete: Task[CompleteInput, CompleteOutput] = _Complete(
@@ -414,7 +414,7 @@ class ControlModel(AlephAlphaModel, ABC):
     ) -> None:
         if name not in self.RECOMMENDED_MODELS or name == "":
             warnings.warn(
-                "The provided model is not a recommended model for this model class."
+                "The provided model is not a recommended model for this model class. "
                 "Make sure that the model you have selected is suited to be use for the prompt template used in this model class."
             )
         super().__init__(name, client)


### PR DESCRIPTION
# Description
Update the `SearchQuery` model in `document_index.py` to allow a `min_score` between -1 and 1.

## Before Merging
 - [ ] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
