### PR TITLE
feat: new Pharia Kernel connector

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -191,6 +191,7 @@ jobs:
           CLIENT_URL: ${{ secrets.CLIENT_URL }}
           STUDIO_URL: "http://localhost:8000/"
           DOCUMENT_INDEX_URL: ${{secrets.DOCUMENT_INDEX_URL}}
+          PHARIA_KERNEL_URL: https://pharia-kernel.product.pharia.com
           POSTGRES_HOST: "localhost"
           POSTGRES_PORT: "5433"
           POSTGRES_DB: "il_sdk"
@@ -225,7 +226,7 @@ jobs:
         env:
           POSTGRES_DB: "il_sdk"
           POSTGRES_USER: "il_sdk"
-          POSTGRES_PASSWORD: "test"    
+          POSTGRES_PASSWORD: "test"
       studio-backend:
         image: registry.gitlab.aleph-alpha.de/product/studio/backend:latest
         ports:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 ...
 ### Features
-+- Add `HybridQdrantInMemoryRetriever` enabling hybrid search for in-memory Qdrant collections
+- New Pharia Kernel connector for calling Skills from a Task
+- Add `HybridQdrantInMemoryRetriever` enabling hybrid search for in-memory Qdrant collections
 
 ### Fixes
  - Add warning to `PromptBasedClassify` and `PromptBasedClassifyWithDefinitions` to be cautious when using them with model families other than luminous

--- a/src/intelligence_layer/connectors/kernel/kernel.py
+++ b/src/intelligence_layer/connectors/kernel/kernel.py
@@ -1,0 +1,67 @@
+from os import getenv
+from typing import TypeVar
+
+import requests
+from pydantic import BaseModel
+
+from intelligence_layer.core import Task, TaskSpan
+
+Input = TypeVar("Input", bound=BaseModel)
+"""Interface to be passed to the task with all data needed to run the process.
+Ideally, these are specified in terms related to the use-case, rather than lower-level
+configuration options."""
+Output = TypeVar("Output", bound=BaseModel)
+"""Interface of the output returned by the task."""
+
+
+class KernelTask(Task[Input, Output]):
+    """A Task that can call a Skill within the Kernel.
+
+    Note: this will not support full tracing in the Intelligence Layer,
+    but it will allow passing a Kernel Skill as a subtask to a larger
+    workflow, or allow for passing it to the Evaluation tooling.
+
+    Args:
+        skill: The name of the skill deployed in Pharia Kernel that should be called.
+        input_model: The type for the Pydantic model that should be used for serializing the input.
+        output_model: The type for the Pydantic model that should be used for deserializing the output.
+        host: The URL to use for accessing Pharia Kernel. Defaults to the env variable `PHARIA_KERNEL_URL` if not provided.
+        token: The auth token to use for accessing Pharia Kernel. Defaults to the env variable `AA_TOKEN` if not provided.
+    """
+
+    def __init__(
+        self,
+        skill: str,
+        input_model: type[Input],
+        output_model: type[Output],
+        host: str | None = None,
+        token: str | None = None,
+    ):
+        if host is None:
+            host = getenv("PHARIA_KERNEL_URL")
+            assert host, "Define PHARIA_KERNEL_URL with a valid url pointing towards your Pharia Kernel API."
+        if token is None:
+            token = getenv("AA_TOKEN")
+            assert token, "Define environment variable AA_TOKEN with a valid token for the Aleph Alpha API"
+
+        self.skill = skill
+        self.input_model = input_model
+        self.output_model = output_model
+        self.host = host
+        self.session = requests.Session()
+        self.session.headers = {"Authorization": f"Bearer {token}"}
+
+    def __del__(self):
+        if self.session:
+            self.session.close()
+
+    def do_run(self, input: Input, task_span: TaskSpan) -> Output:
+        response = self.session.post(
+            f"{self.host}/v1/skills/{self.skill}/run",
+            json=input.model_dump(),
+        )
+
+        if response.status_code != 200:
+            raise Exception(f"{response.status_code}: {response.text}")
+
+        return self.output_model(**response.json())

--- a/tests/connectors/kernel/test_kernel.py
+++ b/tests/connectors/kernel/test_kernel.py
@@ -1,0 +1,28 @@
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
+from intelligence_layer.connectors.kernel.kernel import KernelTask
+from intelligence_layer.core.tracer.tracer import NoOpTracer
+
+
+def test_kernel_connector() -> None:
+    load_dotenv()
+    tracer = NoOpTracer()
+
+    class Input(BaseModel):
+        question: str
+
+    class Output(BaseModel):
+        answer: str | None
+
+    task = KernelTask(
+        skill="app/super_rag",
+        input_model=Input,
+        output_model=Output,
+    )
+
+    output = task.run(
+        Input(question="What is a transformer?"),
+        tracer,
+    )
+    assert output.answer and "transformer" in output.answer


### PR DESCRIPTION
# Description

To allow for using Kernel Skills as either subtasks within an existing Task, or to pass into the Eval framework, this is a basic wrapper around a task that allows for invoking a skill as a Task.

The Pydantic types are passed into the constructor so that they can be callable and also to make mypy generics happy. You can check out the test to see how this would be used.

## Before Merging
 - [x] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [x] Update `changelog.md` if necessary
 - [x] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
