### PR TITLE
fix: add CLIENT_URL to document-index-notebooks step in CI

### DIFF
--- a/.github/workflows/document-index-tests.yml
+++ b/.github/workflows/document-index-tests.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Run Notebooks
         env:
           AA_TOKEN: ${{ secrets.AA_TOKEN }}
+          CLIENT_URL: ${{ secrets.CLIENT_URL }}
           DOCUMENT_INDEX_URL: ${{secrets.DOCUMENT_INDEX_URL}}
         run: |
           ./scripts/notebook_runner_document_index.sh


### PR DESCRIPTION
# Description
No description.

## Before Merging
 - [ ] Review the code changes
    - Unused print / comments / TODOs
    - Missing docstrings for functions that should have them
    - Consistent variable names
    - ...
 - [ ] Update `changelog.md` if necessary
 - [ ] Commit messages should contain a semantic [label](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and the ticket number
   - Consider squashing if this is not the case
