### PR TITLE
Add parameter max_workers to StudioBenchmark.execute

### DIFF
--- a/src/intelligence_layer/evaluation/benchmark/studio_benchmark.py
+++ b/src/intelligence_layer/evaluation/benchmark/studio_benchmark.py
@@ -98,6 +98,7 @@ class StudioBenchmark(Benchmark):
         description: Optional[str] = None,
         labels: Optional[set[str]] = None,
         metadata: Optional[dict[str, Any]] = None,
+        max_workers: int = 10,
     ) -> str:
         start = datetime.now(timezone.utc)
 
@@ -108,7 +109,7 @@ class StudioBenchmark(Benchmark):
             f"benchmark-{self.id}-runner",
         )
         run_overview = runner.run_dataset(
-            self.dataset_id, description=description, labels=labels, metadata=metadata
+            self.dataset_id, description=description, labels=labels, metadata=metadata, max_workers=max_workers
         )
 
         evaluation_overview = self.evaluator.evaluate_runs(

--- a/src/intelligence_layer/evaluation/benchmark/studio_benchmark.py
+++ b/src/intelligence_layer/evaluation/benchmark/studio_benchmark.py
@@ -109,7 +109,11 @@ class StudioBenchmark(Benchmark):
             f"benchmark-{self.id}-runner",
         )
         run_overview = runner.run_dataset(
-            self.dataset_id, description=description, labels=labels, metadata=metadata, max_workers=max_workers
+            self.dataset_id,
+            description=description,
+            labels=labels,
+            metadata=metadata,
+            max_workers=max_workers,
         )
 
         evaluation_overview = self.evaluator.evaluate_runs(


### PR DESCRIPTION
I have added the option to set the number of parallel workers on the execution of a benchmark. This parameter will be passed directly to the runner.

Main reason for the change: some runs involve many API requests and the default (10) will result in timeouts or other concurrency issues. Consequently, valid runs fail due to the unavailability of the resources. Allowing for more control, one can avoid such situations by reducing the load on the API.